### PR TITLE
Added py.typed marker file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="deferred_result",
-    version="0.1.0",
+    version="0.1.1",
     author="Maciej Nowak",
     description="Simple DeferredResult",
     long_description=long_description,


### PR DESCRIPTION
Mypy requires `py.typed` file to be present for packages that support type hints.